### PR TITLE
Fix spelling of 'shulkur_box' in disabled items list

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -31,7 +31,7 @@ statusOnLogin: true
 # Use '*' to disabled every item.
 # Use '-' to invert an item e.g. '- "-shulkur_box"'. This will enable the shulkur_box
 disabledItems:
-  - "shulker_box"
+  - "shulkur_box"
   - "bundle"
 
 money:


### PR DESCRIPTION
There was a spelling error in the disabled items list of the shulkur box which rendered that item enabled.