### PR TITLE
Disabled pickpocket toggling being on by default

### DIFF
--- a/src/main/java/logan/pickpocket/user/RummageInventory.kt
+++ b/src/main/java/logan/pickpocket/user/RummageInventory.kt
@@ -73,9 +73,8 @@ class RummageInventory(private val victim: PickpocketUser) {
         }
         menu.addItem(menu.bottomRight, rummageButton)
         menu.update()
-    }// This item is disabled. Skip this random item iteration.
+    }
 
-    // Check if the item is banned
     private val randomItemsFromPlayer: List<ItemStack>
         get() {
             val randomItemList: MutableList<ItemStack> = ArrayList()

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -16,7 +16,7 @@
 # Allows players to toggle pickpocketing on or off.
 # When pickpockoeting is off for an individual player, they
 # cannot pickpocket others, and others cannot pickpocket them.
-pickpocketToggling: true
+pickpocketToggling: false
 
 # Shows players current pickpocket toggle setting
 # when attempting pickpocket another player.


### PR DESCRIPTION
Changed pickpocket toggling to 'false' in the configuration. This will prevent players from toggling pickpocketing unless the value is changed to 'true'.