### PR TITLE
Change a players toggle status to true when pickpocket toggling is disabled

### DIFF
--- a/src/main/java/logan/pickpocket/config/PickpocketConfiguration.kt
+++ b/src/main/java/logan/pickpocket/config/PickpocketConfiguration.kt
@@ -15,7 +15,7 @@ object PickpocketConfiguration {
     val moneyPercentageToSteal = config.getDouble("money.percentageToSteal")
     var disabledItems = computeDisabledItems()
     val statusOnInteract = config.getBoolean("statusOnInteract")
-    val statusOnLogin = config.getBoolean("statusOnLogin")
+    val showStatusOnLogin = config.getBoolean("showStatusOnLogin")
     val foreignTownTheft = config.getBoolean("foreignTownTheft")
     val sameTownTheft = config.getBoolean("sameTownTheft")
     val databaseEnabled = config.getBoolean("database.enabled")

--- a/src/main/java/logan/pickpocket/listeners/PlayerJoinListener.kt
+++ b/src/main/java/logan/pickpocket/listeners/PlayerJoinListener.kt
@@ -21,7 +21,7 @@ class PlayerJoinListener : Listener {
         val user = PickpocketUser.get(event.player)
         validateUserToggleStatus(user)
 
-        if (PickpocketConfiguration.statusOnLogin)
+        if (PickpocketConfiguration.showStatusOnLogin)
             showStatusMessage(user)
     }
 

--- a/src/main/java/logan/pickpocket/listeners/PlayerJoinListener.kt
+++ b/src/main/java/logan/pickpocket/listeners/PlayerJoinListener.kt
@@ -4,6 +4,7 @@ import logan.pickpocket.config.MessageConfiguration
 import logan.pickpocket.config.PickpocketConfiguration
 import logan.pickpocket.main.PickpocketPlugin
 import logan.pickpocket.user.PickpocketUser
+import org.apache.logging.log4j.message.Message
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
 import org.bukkit.event.player.PlayerJoinEvent
@@ -32,9 +33,8 @@ class PlayerJoinListener : Listener {
     }
 
     private fun showStatusMessage(user: PickpocketUser) {
-        if (user.isParticipating)
-            user.bukkitPlayer.sendMessage(MessageConfiguration.participatingTrueNotificationMessage)
-        else
-            user.bukkitPlayer.sendMessage(MessageConfiguration.participatingFalseNotificationMessage)
+        val message =
+            if (user.isParticipating) MessageConfiguration.participatingTrueNotificationMessage else MessageConfiguration.participatingFalseNotificationMessage
+        user.bukkitPlayer.sendMessage(message)
     }
 }

--- a/src/main/java/logan/pickpocket/listeners/PlayerJoinListener.kt
+++ b/src/main/java/logan/pickpocket/listeners/PlayerJoinListener.kt
@@ -18,16 +18,23 @@ class PlayerJoinListener : Listener {
 
     @EventHandler
     fun onPlayerJoin(event: PlayerJoinEvent) {
-
         val user = PickpocketUser.get(event.player)
+        validateUserToggleStatus(user)
 
-        // return without showing status message
-        if (!PickpocketConfiguration.statusOnLogin) return
+        if (PickpocketConfiguration.statusOnLogin)
+            showStatusMessage(user)
+    }
 
-        // show status message
+    private fun validateUserToggleStatus(user: PickpocketUser) {
+        if (!PickpocketConfiguration.isParticipationTogglingEnabled) {
+            user.isParticipating = true
+        }
+    }
+
+    private fun showStatusMessage(user: PickpocketUser) {
         if (user.isParticipating)
-            event.player.sendMessage(MessageConfiguration.participatingTrueNotificationMessage)
+            user.bukkitPlayer.sendMessage(MessageConfiguration.participatingTrueNotificationMessage)
         else
-            event.player.sendMessage(MessageConfiguration.participatingFalseNotificationMessage)
+            user.bukkitPlayer.sendMessage(MessageConfiguration.participatingFalseNotificationMessage)
     }
 }

--- a/src/main/java/logan/pickpocket/user/RummageInventory.kt
+++ b/src/main/java/logan/pickpocket/user/RummageInventory.kt
@@ -73,9 +73,8 @@ class RummageInventory(private val victim: PickpocketUser) {
         }
         menu.addItem(menu.bottomRight, rummageButton)
         menu.update()
-    }// This item is disabled. Skip this random item iteration.
+    }
 
-    // Check if the item is banned
     private val randomItemsFromPlayer: List<ItemStack>
         get() {
             val randomItemList: MutableList<ItemStack> = ArrayList()

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -24,7 +24,7 @@ statusOnInteract: true
 
 # Shows players current pickpocket toggle setting
 # when logging into the server.
-statusOnLogin: true
+showStatusOnLogin: true
 
 # Items that cannot be pickpocketed.
 #

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -16,7 +16,7 @@
 # Allows players to toggle pickpocketing on or off.
 # When pickpockoeting is off for an individual player, they
 # cannot pickpocket others, and others cannot pickpocket them.
-pickpocketToggling: true
+pickpocketToggling: false
 
 # Shows players current pickpocket toggle setting
 # when attempting pickpocket another player.


### PR DESCRIPTION
When the player joins their toggle status may be changed to true if pickpocket toggling is disabled in the configuration. This prevents players being stuck in a false toggle which prevents other players from pickpocketing them.

Closes #123